### PR TITLE
Creating API documentation for movies using express-swagger-ui

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -6,7 +6,30 @@
     "title": "Movie API"
   },
   "host": "localhost:8000",
+  "securityDefinitions": {
+    "JWT": {
+      "in": "header",
+      "name": "Authorization",
+      "type": "apiKey"
+    }
+  },
   "paths": {
+    "/api/movies": {
+      "get": {
+        "tags": ["Movies"],
+        "summary": "Get Movies",
+        "description": "User will get all movies",
+        "security": [{ "JWT": {} }],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
     "/api/users/signin": {
       "post": {
         "tags": ["Users"],


### PR DESCRIPTION
Creating API docs for movies using swagger-ui-express which allows users to get all the movies 
1. First execute the users api for login 
2. Click on **Try it out** button
3. Type **email** and **password** in **User Credentials**
4. Click on **Execute** button
5. Copy the token from response

![User Sign In](https://github.com/user-attachments/assets/cb18674e-f21c-4cd3-a682-82a0368b0d77)

6. Click on **Athorize** button
7. Paste token in **value** box and click on 'Authorize'

![Get Authorized](https://github.com/user-attachments/assets/33211c5d-090c-4a7b-b131-0d7e0a7248ee)

8. Go to Movie Api
9. Click on **Try it out** button 
10. Click on **Execute**

![Get Movies](https://github.com/user-attachments/assets/35f36c8c-dcc6-4888-a708-0a6bc48413c9)
